### PR TITLE
Partially concealable italics/bold/code

### DIFF
--- a/doc/asciidoctor.txt
+++ b/doc/asciidoctor.txt
@@ -105,6 +105,15 @@ one needs settings to set.
   let g:asciidoctor_syntax_indented = 0
 
 
+*g:asciidoctor_syntax_conceal*        Enable concealable syntax.
+                                    Currently it only works inside regular
+                                    paragraphs and lists.
+                                    Default: 0
+  Example: 
+
+  let g:asciidoctor_syntax_conceal = 1
+
+
 *g:asciidoctor_fold_options*          Fold options (usually under the title).
                                     Default: 0
   Example: 

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -89,7 +89,7 @@ syn match asciidoctorCode /\%(^\|[[:punct:][:space:]]\@<=\)`[^` ].\{-}\S`\%([[:p
 syn match asciidoctorCode /\%(^\|[[:punct:][:space:]]\@<=\)`[^` ]`\%([[:punct:][:space:]]\@=\|$\)/
 syn match asciidoctorCode /``.\{-}``/
 
-if get(g:, 'asciidoctor_syntax_concealed', 0)
+if get(g:, 'asciidoctor_syntax_conceal', 0)
   syn match asciidoctorParagraph '^\([_`*]\+\)\?\k.*' contains=ALL
   syn match asciidoctorList      "^\s*\%(\%(-\|[*.]\+\|\d\+\.\|\a\.\)\s\+\)\@=.*\(\n\s\+\S.*\)*" contains=ALL
 

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -93,12 +93,12 @@ if get(g:, 'asciidoctor_syntax_concealed', 0)
   syn match asciidoctorParagraph '^[_`*]\?\k.*' contains=ALL
   syn match asciidoctorList      "^\s*\%(\%(-\|[*.]\+\|\d\+\.\|\a\.\)\s\+\)\@=.*\(\n\s\+\S.*\)*" contains=ALL
 
-  syn region asciidoctorBold       matchgroup=Conceal start=/\m\*\+\ze\S\+\*\+/        end=/\*\+/ contained contains=@Spell concealends
-  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\+\ze\S\+_\+/          end=/_\+/  contained contains=@Spell concealends
+  syn region asciidoctorBold       matchgroup=Conceal start=/\m\(\*\+\)\ze[^* \t]\+\1/ end=/\*\+/ contained contains=@Spell concealends
+  syn region asciidoctorItalic     matchgroup=Conceal start=/\m\(_\+\)\ze[^_ \t]\+\1/  end=/_\+/  contained contains=@Spell concealends
   syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\+\ze\%(\k\|\s\)\+_\+/ end=/_\+/  contained contains=@Spell concealends
-  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*_\ze\S\+_\*/          end=/_\*/  contained contains=@Spell concealends
-  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m_\*\ze\S\+\*_/          end=/\*_/  contained contains=@Spell concealends
-  syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\S\+`\+/          end=/`\+/  contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\(\*_\)\ze[^* \t]\+\1/  end=/_\*/  contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\(_\*\)\ze[^_ \t]\+\1/  end=/\*_/  contained contains=@Spell concealends
+  syn region asciidoctorCode       matchgroup=Conceal start=/\m\(`\+\)\ze[^` \t]\+\1/  end=/`\+/  contained contains=@Spell concealends
   syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\%(\k\|\s\)\+`\+/ end=/`\+/  contained contains=@Spell concealends
 endif
 

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -89,6 +89,19 @@ syn match asciidoctorCode /\%(^\|[[:punct:][:space:]]\@<=\)`[^` ].\{-}\S`\%([[:p
 syn match asciidoctorCode /\%(^\|[[:punct:][:space:]]\@<=\)`[^` ]`\%([[:punct:][:space:]]\@=\|$\)/
 syn match asciidoctorCode /``.\{-}``/
 
+if get(g:, 'asciidoctor_syntax_concealed', 0)
+  syn match asciidoctorParagraph '^[_`*]\?\k.*' contains=ALL
+  syn match asciidoctorList      "^\s*\%(\%(-\|[*.]\+\|\d\+\.\|\a\.\)\s\+\)\@=.*\(\n\s\+\S.*\)*" contains=ALL
+
+  syn region asciidoctorBold       matchgroup=Conceal start=/\m\*\ze\S\+\*/            end=/\*/   contained contains=@Spell concealends
+  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\ze\S\+_/              end=/_/    contained contains=@Spell concealends
+  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\ze\%(\k\|\s\)\+_/     end=/_/    contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*_\ze\S\+_\*/          end=/_\*/  contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m_\*\ze\S\+\*_/          end=/\*_/  contained contains=@Spell concealends
+  syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\S\+`\+/          end=/`\+/  contained contains=@Spell concealends
+  syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\%(\k\|\s\)\+`\+/ end=/`\+/  contained contains=@Spell concealends
+endif
+
 syn match asciidoctorAdmonition /\C^\%(NOTE:\)\|\%(TIP:\)\|\%(IMPORTANT:\)\|\%(CAUTION:\)\|\%(WARNING:\)\s/
 
 syn match asciidoctorCaption "^\.[^.[:space:]].*$" contains=@asciidoctorInline,@Spell

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -90,14 +90,14 @@ syn match asciidoctorCode /\%(^\|[[:punct:][:space:]]\@<=\)`[^` ]`\%([[:punct:][
 syn match asciidoctorCode /``.\{-}``/
 
 if get(g:, 'asciidoctor_syntax_concealed', 0)
-  syn match asciidoctorParagraph '^[_`*]\?\k.*' contains=ALL
+  syn match asciidoctorParagraph '^\([_`*]\+\)\?\k.*' contains=ALL
   syn match asciidoctorList      "^\s*\%(\%(-\|[*.]\+\|\d\+\.\|\a\.\)\s\+\)\@=.*\(\n\s\+\S.*\)*" contains=ALL
 
   syn region asciidoctorBold       matchgroup=Conceal start=/\m\(\*\+\)\ze[^* \t]\+\1/ end=/\*\+/ contained contains=@Spell concealends
   syn region asciidoctorItalic     matchgroup=Conceal start=/\m\(_\+\)\ze[^_ \t]\+\1/  end=/_\+/  contained contains=@Spell concealends
   syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\+\ze\%(\k\|\s\)\+_\+/ end=/_\+/  contained contains=@Spell concealends
-  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\(\*_\)\ze[^* \t]\+\1/  end=/_\*/  contained contains=@Spell concealends
-  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\(_\*\)\ze[^_ \t]\+\1/  end=/\*_/  contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*_\ze[^_ \t]\+_\*/     end=/_\*/  contained contains=@Spell concealends
+  syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m_\*\ze[^* \t]\+\*_/     end=/\*_/  contained contains=@Spell concealends
   syn region asciidoctorCode       matchgroup=Conceal start=/\m\(`\+\)\ze[^` \t]\+\1/  end=/`\+/  contained contains=@Spell concealends
   syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\%(\k\|\s\)\+`\+/ end=/`\+/  contained contains=@Spell concealends
 endif

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -93,9 +93,9 @@ if get(g:, 'asciidoctor_syntax_concealed', 0)
   syn match asciidoctorParagraph '^[_`*]\?\k.*' contains=ALL
   syn match asciidoctorList      "^\s*\%(\%(-\|[*.]\+\|\d\+\.\|\a\.\)\s\+\)\@=.*\(\n\s\+\S.*\)*" contains=ALL
 
-  syn region asciidoctorBold       matchgroup=Conceal start=/\m\*\ze\S\+\*/            end=/\*/   contained contains=@Spell concealends
-  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\ze\S\+_/              end=/_/    contained contains=@Spell concealends
-  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\ze\%(\k\|\s\)\+_/     end=/_/    contained contains=@Spell concealends
+  syn region asciidoctorBold       matchgroup=Conceal start=/\m\*\+\ze\S\+\*\+/        end=/\*\+/ contained contains=@Spell concealends
+  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\+\ze\S\+_\+/          end=/_\+/  contained contains=@Spell concealends
+  syn region asciidoctorItalic     matchgroup=Conceal start=/\m_\+\ze\%(\k\|\s\)\+_\+/ end=/_\+/  contained contains=@Spell concealends
   syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*_\ze\S\+_\*/          end=/_\*/  contained contains=@Spell concealends
   syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m_\*\ze\S\+\*_/          end=/\*_/  contained contains=@Spell concealends
   syn region asciidoctorCode       matchgroup=Conceal start=/\m`\+\ze\S\+`\+/          end=/`\+/  contained contains=@Spell concealends


### PR DESCRIPTION
Delimiters must reside in the same line. Concealment is limited to:

- sequences of non-space characters of any kind
- groups of (keyword) characters, separated by spaces (italic and code only)

Enable it by setting g:asciidoctor_syntax_concealed to 1.

The new groups are marked as 'contained', to avoid their inclusion in
non-paragraph blocks. A couple syntax groups had to be created for this
to work (asciidoctorParagraph and asciidoctorList).

I only tested with the documents I work with, not sure if there are side
effects, it's disabled by default.