### PR TITLE
asciidoctorTableBlock recognizes long separators

### DIFF
--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -192,9 +192,9 @@ syn match asciidoctorBlock "^\*\*\*\*\+\s*$"
 
 " Table blocks
 syn match asciidoctorTableCell "\(^\|\s\)\@<=[.+*<^>aehlmdsv[:digit:]]\+|\||" contained containedin=asciidoctorTableBlock
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^|===\s*$" end="^|===\s*$" keepend contains=asciidoctorTableCell,asciidoctorIndented,@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^,===\s*$" end="^,===\s*$" keepend
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;===\s*$" end="^;===\s*$" keepend
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^|===\+\s*$" end="^|===\+\s*$" keepend contains=asciidoctorTableCell,asciidoctorIndented,@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^,===\+\s*$" end="^,===\+\s*$" keepend
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;===\+\s*$" end="^;===\+\s*$" keepend
 
 syn match asciidoctorComment "^//.*$" contains=@Spell
 

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -192,9 +192,9 @@ syn match asciidoctorBlock "^\*\*\*\*\+\s*$"
 
 " Table blocks
 syn match asciidoctorTableCell "\(^\|\s\)\@<=[.+*<^>aehlmdsv[:digit:]]\+|\||" contained containedin=asciidoctorTableBlock
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^|===\+\s*$" end="^|===\+\s*$" keepend contains=asciidoctorTableCell,asciidoctorIndented,@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^,===\+\s*$" end="^,===\+\s*$" keepend
-syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;===\+\s*$" end="^;===\+\s*$" keepend
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^|\z(===\+\)\s*$" end="^|\z1\s*$" keepend contains=asciidoctorTableCell,asciidoctorIndented,@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^,\z(===\+\)\s*$" end="^,\z1\s*$" keepend
+syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;\z(===\+\)\s*$" end="^;\z1\s*$" keepend
 
 syn match asciidoctorComment "^//.*$" contains=@Spell
 


### PR DESCRIPTION
Long table separators like this weren't working:

![Imgur](https://i.imgur.com/yM8qNhy.jpg)