### PR TITLE
Unify header matches for better performance

### DIFF
--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -53,11 +53,7 @@ syn region asciidoctorH4 start="^=====\s" end="$" oneline contains=@asciidoctorI
 syn region asciidoctorH5 start="^======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 syn region asciidoctorH6 start="^=======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 
-syn match asciidoctorH1 '^\%(\n\|\%^\)\k\+.*\n==\+\n$'   contains=@Spell
-syn match asciidoctorH2 '^\%(\n\|\%^\)\k\+.*\n--\+\n$'   contains=@Spell
-syn match asciidoctorH3 '^\%(\n\|\%^\)\k\+.*\n\~\~\+\n$' contains=@Spell
-syn match asciidoctorH4 '^\%(\n\|\%^\)\k\+.*\n\^\^\+\n$' contains=@Spell
-syn match asciidoctorH5 '^\%(\n\|\%^\)\k\+.*\n++\+\n$'   contains=@Spell
+syn match asciidoctorH '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}\n$'   contains=@Spell
 
 syn sync clear
 syn sync match syncH1 grouphere NONE "^==\s.*$"

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -201,6 +201,7 @@ syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;===\s*$" e
 syn match asciidoctorComment "^//.*$" contains=@Spell
 
 hi def link asciidoctorTitle                 Title
+hi def link asciidoctorH                     Title
 hi def link asciidoctorH1                    Title
 hi def link asciidoctorH2                    Title
 hi def link asciidoctorH3                    Title

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -53,7 +53,7 @@ syn region asciidoctorH4 start="^=====\s" end="$" oneline contains=@asciidoctorI
 syn region asciidoctorH5 start="^======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 syn region asciidoctorH6 start="^=======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 
-syn match asciidoctorH '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}\n$'   contains=@Spell
+syn match asciidoctorSetextHeader  '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}\n$'   contains=@Spell
 
 syn sync clear
 syn sync match syncH1 grouphere NONE "^==\s.*$"
@@ -201,7 +201,7 @@ syn region asciidoctorTableBlock matchgroup=asciidoctorBlock start="^;===\s*$" e
 syn match asciidoctorComment "^//.*$" contains=@Spell
 
 hi def link asciidoctorTitle                 Title
-hi def link asciidoctorH                     Title
+hi def link asciidoctorSetextHeader          Title
 hi def link asciidoctorH1                    Title
 hi def link asciidoctorH2                    Title
 hi def link asciidoctorH3                    Title

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -53,7 +53,7 @@ syn region asciidoctorH4 start="^=====\s" end="$" oneline contains=@asciidoctorI
 syn region asciidoctorH5 start="^======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 syn region asciidoctorH6 start="^=======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 
-syn match asciidoctorSetextHeader  '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}$'   contains=@Spell
+syn match asciidoctorSetextHeader '^\%(\n\|\%^\)\k.*\n\%(=\+\|\-\+\|\~\+\|\^\+\|+\+\)$'   contains=@Spell
 
 syn sync clear
 syn sync match syncH1 grouphere NONE "^==\s.*$"

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -53,7 +53,7 @@ syn region asciidoctorH4 start="^=====\s" end="$" oneline contains=@asciidoctorI
 syn region asciidoctorH5 start="^======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 syn region asciidoctorH6 start="^=======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 
-syn match asciidoctorSetextHeader  '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}\n$'   contains=@Spell
+syn match asciidoctorSetextHeader  '^\%(\n\|\%^\)\k\+.*\n[=\-~^+]\{2,}$'   contains=@Spell
 
 syn sync clear
 syn sync match syncH1 grouphere NONE "^==\s.*$"


### PR DESCRIPTION
The new matches from #36 are a bit slow, this should mitigate their impact, does it matter if the kind of header (H1, H2, etc) is lost?