### PR TITLE
Fix list continuations with +

### DIFF
--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -53,7 +53,7 @@ syn region asciidoctorH4 start="^=====\s" end="$" oneline contains=@asciidoctorI
 syn region asciidoctorH5 start="^======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 syn region asciidoctorH6 start="^=======\s" end="$" oneline contains=@asciidoctorInline,@Spell
 
-syn match asciidoctorSetextHeader '^\%(\n\|\%^\)\k.*\n\%(=\+\|\-\+\|\~\+\|\^\+\|+\+\)$'   contains=@Spell
+syn match asciidoctorSetextHeader '^\%(\n\|\%^\)\k.*\n\%(==\+\|\-\-\+\|\~\~\+\|\^\^\+\|++\+\)$'   contains=@Spell
 
 syn sync clear
 syn sync match syncH1 grouphere NONE "^==\s.*$"


### PR DESCRIPTION
Broken by #36, since a line with a plus sign can also be a header
For lack of better solutions, setext headers should have at least two
characters (even if not really required by asciidoc) to be properly
highlighted.

Right:

![Imgur](https://i.imgur.com/Anm3VFf.jpg)

Wrong:

![Imgur](https://i.imgur.com/wGMpkyI.jpg)