### PR TITLE
Email links highlight and conceal

### DIFF
--- a/autoload/asciidoctor.vim
+++ b/autoload/asciidoctor.vim
@@ -1,5 +1,5 @@
 " Maintainer: Maxim Kim (habamax@gmail.com)
-" vim: set noet
+" vim: noet
 
 if exists("g:loaded_asciidoctor_autoload")
     finish

--- a/compiler/asciidoctor2docx.vim
+++ b/compiler/asciidoctor2docx.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Asciidoctor 2 DOCX using docbook intermediate format and pandoc
 " Maintainer: Maxim Kim (habamax@gmail.com)
-" vim: set noet
+" vim: noet
 
 if exists("current_compiler")
 	finish

--- a/compiler/asciidoctor2html.vim
+++ b/compiler/asciidoctor2html.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Asciidoctor2HTML
 " Maintainer: Maxim Kim (habamax@gmail.com)
-" vim: set noet
+" vim: noet
 
 if exists("current_compiler")
   finish

--- a/compiler/asciidoctor2pdf.vim
+++ b/compiler/asciidoctor2pdf.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Asciidoctor2PDF
 " Maintainer: Maxim Kim (habamax@gmail.com)
-" vim: set noet
+" vim: noet
 
 if exists("current_compiler")
 	finish

--- a/ftplugin/asciidoctor.vim
+++ b/ftplugin/asciidoctor.vim
@@ -2,7 +2,7 @@
 " Language:   asciidoctor
 " Maintainer: Maxim Kim <habamax@gmail.com>
 " Filenames:  *.adoc
-" vim: set noet
+" vim: noet
 
 if exists("b:did_ftplugin")
 	finish

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -40,6 +40,7 @@ syn match asciidoctorPageBreak "^<<<\+\s*$"
 syn cluster asciidoctorBlock contains=asciidoctorTitle,asciidoctorH1,asciidoctorH2,asciidoctorH3,asciidoctorH4,asciidoctorH5,asciidoctorH6,asciidoctorBlockquote,asciidoctorListMarker,asciidoctorOrderedListMarker,asciidoctorCodeBlock,asciidoctorAdmonition,asciidoctorAdmonitionBlock
 syn cluster asciidoctorInnerBlock contains=asciidoctorBlockquote,asciidoctorListMarker,asciidoctorOrderedListMarker,asciidoctorCodeBlock,asciidoctorDefList,asciidoctorAdmonition,asciidoctorAdmonitionBlock
 syn cluster asciidoctorInline contains=asciidoctorItalic,asciidoctorBold,asciidoctorCode,asciidoctorBoldItalic,asciidoctorUrl,asciidoctorUrlAuto,asciidoctorLink,asciidoctorAnchor,asciidoctorMacro,asciidoctorAttribute,asciidoctorInlineAnchor
+syn cluster asciidoctorUrls contains=asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,asciidoctorEmailAuto
 
 " really hard to use them together with all the rest 'blocks'
 " syn match asciidoctorMarkdownH1 "^\s*[[:alpha:]].\+\n=\+$" contains=@asciidoctorInline
@@ -158,11 +159,11 @@ syn match asciidoctorInlineAnchor "\[\[.\{-}\]\]"
 " block that will not be
 " highlighted
 " --
-syn region asciidoctorListingBlock matchgroup=asciidoctorBlock start="^\z(--\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,asciidoctorTableCell,@asciidoctorInline
+syn region asciidoctorListingBlock matchgroup=asciidoctorBlock start="^\z(--\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,asciidoctorTableCell,@asciidoctorInline,@asciidoctorUrls
 
 " General [source] block
-syn region asciidoctorSourceBlock matchgroup=asciidoctorBlock start="^\[source\%(,.*\)*\]\s*$" end="^\s*$" keepend contains=CONTAINED,asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,asciidoctorTableCell,@asciidoctorInline
-syn region asciidoctorSourceBlock matchgroup=asciidoctorBlock start="^\[source\%(,.*\)*\]\s*\n\z(--\+\)\s*$" end="^.*\n\zs\z1\s*$" keepend contains=CONTAINED,asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,asciidoctorTableCell,@asciidoctorInline
+syn region asciidoctorSourceBlock matchgroup=asciidoctorBlock start="^\[source\%(,.*\)*\]\s*$" end="^\s*$" keepend contains=CONTAINED,asciidoctorTableCell,@asciidoctorInline,@asciidoctorUrls
+syn region asciidoctorSourceBlock matchgroup=asciidoctorBlock start="^\[source\%(,.*\)*\]\s*\n\z(--\+\)\s*$" end="^.*\n\zs\z1\s*$" keepend contains=CONTAINED,asciidoctorTableCell,@asciidoctorInline,@asciidoctorUrls
 
 " Source highlighting with programming languages
 if main_syntax ==# 'asciidoctor'
@@ -214,8 +215,8 @@ syn region asciidoctorPlantumlBlock matchgroup=asciidoctorBlock start="^\[plantu
 
 " Contents of literal blocks should not be highlighted
 " TODO: make [literal] works with paragraph
-syn region asciidoctorLiteralBlock matchgroup=asciidoctorBlock start="^\z(\.\.\.\.\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,@Spell,asciidoctorComment,asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,@asciidoctorInline
-syn region asciidoctorExampleBlock matchgroup=asciidoctorBlock start="^\z(====\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,@Spell,asciidoctorComment,asciidoctorUrlDescription,asciidoctorFile,asciidoctorUrlAuto,@asciidoctorInline
+syn region asciidoctorLiteralBlock matchgroup=asciidoctorBlock start="^\z(\.\.\.\.\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,@Spell,asciidoctorComment,@asciidoctorInline,@asciidoctorUrls
+syn region asciidoctorExampleBlock matchgroup=asciidoctorBlock start="^\z(====\+\)\s*$" end="^\z1\s*$" contains=CONTAINED,@Spell,asciidoctorComment,@asciidoctorInline,@asciidoctorUrls
 syn region asciidoctorSidebarBlock matchgroup=asciidoctorBlock start="^\z(\*\*\*\*\+\)\s*$" end="^\z1\s*$" contains=@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
 syn region asciidoctorQuoteBlock   matchgroup=asciidoctorBlock start="^\z(____\+\)\s*$" end="^\z1\s*$" contains=@asciidoctorInnerBlock,@asciidoctorInline,@Spell,asciidoctorComment
 

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -2,7 +2,7 @@
 " Language:     asciidoctor
 " Maintainer:   Maxim Kim <habamax@gmail.com>
 " Filenames:    *.adoc
-" vim: set noet
+" vim: noet
 
 if exists("b:current_syntax")
 	finish


### PR DESCRIPTION
![Imgur](https://i.imgur.com/IL4tMmB.png)

It also handles `irc://`.

First commit is because modelines were broken in the old format.