### PR TITLE
Ignore help tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When installing vim-asciidoctor as a git submodule, running :helptags on vim-asciidoctor leaves the submodule in an unclean state. To avoid this, add the generated doc/tags file to the .gitignore.