### PR TITLE
Enable images from URIs to be sourced and output with Asciidoctor2PDF

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -336,6 +336,27 @@ The name of the image is generated according to the pattern. By default it is
 
  img_ + document_base_name + next_image_number + .png
 
+== Images from URIs
+
+To include content by URI, including images, requires setting the `allow-uri-read` attribute.  It is not enabled by default for reasons noted in the Asciidoctor documentation at
+https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/[Include Content by URI].
+
+If you are sure the URIs in a file are &#x201c;safe&#x201d;, either enter
+the following on the command line or add it to your ~/.vimrc:
+
+[source,vim]
+--------
+let g:asciidoctor_allow_uri_read = " -a allow-uri-read"
+--------
+
+Now images from URIs will be processed, e.g., a block image like the following would be processed to the PDF output:
+
+[literal]
+.........
+
+image::https://www.debian.org/logos/openlogo-100.jpg[debian-openlogo-100]
+
+.........
 
 == Bibliography completion
 

--- a/compiler/asciidoctor2pdf.vim
+++ b/compiler/asciidoctor2pdf.vim
@@ -6,6 +6,10 @@
 if exists("current_compiler")
     finish
 endif
+" Use let g:asciidoctor_allow_uri_read = " -a allow-uri-read" in your .vimrc
+" to enable including images from URIs.  Use this with care!  Refer:
+" https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/
+let g:asciidoctor_allow_uri_read = exists("g:asciidoctor_allow_uri_read") ? g:asciidoctor_allow_uri_read : ""
 let current_compiler = "Asciidoctor2PDF"
 let s:keepcpo= &cpo
 set cpo&vim
@@ -47,6 +51,7 @@ let s:asciidoctor_pdf_executable = get(g:, 'asciidoctor_pdf_executable', 'asciid
 let s:filename = shellescape(get(g:, 'asciidoctor_use_fullpath', v:true) ? expand("%:p") : expand("%:t"))
 
 let &l:makeprg = s:asciidoctor_pdf_executable . " " . s:extensions
+            \. g:asciidoctor_allow_uri_read
             \. " -a docdate=" . strftime("%Y-%m-%d")
             \. " -a doctime=" . strftime("%H:%M:%S") . " "
             \. s:pdf_themes_path . " "


### PR DESCRIPTION
I love vim-asciidoctor though found images _from URIs_ would not be sourced or included when using Asciidoctor2PDF.

I've added a few lines of code to asciidoctor2pdf.vim (variable `g:asciidoctor_allow_uri_read`), tested it, and it works (for .jpg and .png files anyhow), and has no impact if the variable is not set (i.e., to ` -a allow-uri-read`, which is what enables it).

I thought is was worth having it considered, so include it if you want to.  I updated the README.adoc too if it is used.

Cheers