### PR TITLE
Added support for multiline bold, italic and bolditalic

### DIFF
--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -97,13 +97,13 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
     " TODO: Fix single character not matched. E.g.: *b*. \S seems to be the
     " issue
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
-    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*\*_/ end=/_\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorCode matchgroup=Conceal start=/\m``/ end=/``/ contains=@Spell concealends oneline
     syn region asciidoctorCode matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)`\ze[^` ].\{-}\S/ end=/`\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
@@ -114,17 +114,17 @@ else
 
     syn match asciidoctorAnchor "<<.\{-}>>"
 
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *b* bold
     syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^ ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBold /\*\*\S.\{-}\*\*/ contains=@Spell
 
-    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char _b_ italic
     syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorItalic /__\S.\{-}__/ contains=@Spell
 
-    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *_b_* bold+italic
     syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBoldItalic /\*\*_\S.\{-}_\*\*/ contains=@Spell

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -95,7 +95,7 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
     syn region asciidoctorAnchor matchgroup=Conceal start="<<\%([^>]\{-},\s*\)\?\ze.\{-}>>" end=">>" concealends oneline
 
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^* ].\(.\|\n\(\s*\n\)\@!\)\{-}\S/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ].\(.\|\n\(\s*\n\)\@!\)\{-}/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
     syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^_ ].\{-}\S/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
@@ -112,17 +112,17 @@ else
 
     syn match asciidoctorAnchor "<<.\{-}>>"
 
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^* ].\(.\|\n\(\s*\n\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *b* bold
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^* ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^ ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBold /\*\*\S.\{-}\*\*/ contains=@Spell
 
-    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ].\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char _b_ italic
     syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorItalic /__\S.\{-}__/ contains=@Spell
 
-    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ].\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *_b_* bold+italic
     syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBoldItalic /\*\*_\S.\{-}_\*\*/ contains=@Spell

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -94,14 +94,16 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
 
     syn region asciidoctorAnchor matchgroup=Conceal start="<<\%([^>]\{-},\s*\)\?\ze.\{-}>>" end=">>" concealends oneline
 
+    " TODO: Fix single character not matched. E.g.: *b*. \S seems to be the
+    " issue
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ].\(.\|\n\(\s*\n\)\@!\)\{-}/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
-    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^_ ].\{-}\S/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
+    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*\*_/ end=/_\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ].\{-}\S/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
+    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorCode matchgroup=Conceal start=/\m``/ end=/``/ contains=@Spell concealends oneline
     syn region asciidoctorCode matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)`\ze[^` ].\{-}\S/ end=/`\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -95,7 +95,7 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
     syn region asciidoctorAnchor matchgroup=Conceal start="<<\%([^>]\{-},\s*\)\?\ze.\{-}>>" end=">>" concealends oneline
 
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^* ].\{-}\S/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^* ].\(.\|\n\(\s*\n\)\@!\)\{-}\S/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
     syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^_ ].\{-}\S/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
@@ -112,7 +112,7 @@ else
 
     syn match asciidoctorAnchor "<<.\{-}>>"
 
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^* ].\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^* ].\(.\|\n\(\s*\n\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *b* bold
     syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^* ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBold /\*\*\S.\{-}\*\*/ contains=@Spell

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -97,13 +97,13 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
     " TODO: Fix single character not matched. E.g.: *b*. \S seems to be the
     " issue
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
-    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*\*_/ end=/_\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorCode matchgroup=Conceal start=/\m``/ end=/``/ contains=@Spell concealends oneline
     syn region asciidoctorCode matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)`\ze[^` ].\{-}\S/ end=/`\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
@@ -114,17 +114,17 @@ else
 
     syn match asciidoctorAnchor "<<.\{-}>>"
 
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *b* bold
     syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^ ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBold /\*\*\S.\{-}\*\*/ contains=@Spell
 
-    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char _b_ italic
     syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorItalic /__\S.\{-}__/ contains=@Spell
 
-    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.]\)\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *_b_* bold+italic
     syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBoldItalic /\*\*_\S.\{-}_\*\*/ contains=@Spell

--- a/syntax/asciidoctor.vim
+++ b/syntax/asciidoctor.vim
@@ -97,13 +97,13 @@ if get(g:, 'asciidoctor_syntax_conceal', 0)
     " TODO: Fix single character not matched. E.g.: *b*. \S seems to be the
     " issue
     syn region asciidoctorBold matchgroup=Conceal start=/\m\*\*/ end=/\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBold matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!\*/ end=/\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorItalic matchgroup=Conceal start=/\m__/ end=/__/ contains=@Spell concealends oneline
-    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!_/ end=/_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\*\*_/ end=/_\*\*/ contains=@Spell concealends oneline
-    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
+    syn region asciidoctorBoldItalic matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)\*_\ze[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\(^\)\@<!_\*/ end=/_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends
 
     syn region asciidoctorCode matchgroup=Conceal start=/\m``/ end=/``/ contains=@Spell concealends oneline
     syn region asciidoctorCode matchgroup=Conceal start=/\m\%(^\|[[:punct:][:space:]]\@<=\)`\ze[^` ].\{-}\S/ end=/`\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell concealends oneline
@@ -114,17 +114,17 @@ else
 
     syn match asciidoctorAnchor "<<.\{-}>>"
 
-    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *b* bold
     syn match asciidoctorBold /\%(^\|[[:punct:][:space:]]\@<=\)\*[^ ]\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBold /\*\*\S.\{-}\*\*/ contains=@Spell
 
-    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char _b_ italic
     syn match asciidoctorItalic /\%(^\|[[:punct:][:space:]]\@<=\)_[^_ ]_\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorItalic /__\S.\{-}__/ contains=@Spell
 
-    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\s*\n\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
+    syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]\(.\|\n\(\(\s*\n\)\|\(^\s*[*.] \)\)\@!\)\{-}\S_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     " single char *_b_* bold+italic
     syn match asciidoctorBoldItalic /\%(^\|[[:punct:][:space:]]\@<=\)\*_[^*_ ]_\*\%([[:punct:][:space:]]\@=\|$\)/ contains=@Spell
     syn match asciidoctorBoldItalic /\*\*_\S.\{-}_\*\*/ contains=@Spell


### PR DESCRIPTION
As discussed in https://github.com/habamax/vim-asciidoctor/issues/58

Modified the relevant parts of `syntax/asciidoctor.vim` to display bold, italics and bolditalics correctly when they span more than one line (so it works for hard wraped files). It adds the `\(.\|\n\(\(\s*\n\)\|\(^\s*[*.-]\)\)\@!\)` clause to include newlines that aren't empty or the beginning of a list item. It also adds a check for the closing match of the pattern for the definitions that depend on `g:asciidoctor_syntax_conceal`, so that they're not highlighted if they aren't closed.

Also, I don't know if it makes any difference but I opted to modify the * definition so that it doesn't overlap with *_'s. 